### PR TITLE
Subtracting more points on questions answered quickly

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -915,7 +915,7 @@ class TriviaTime(callbacks.Plugin):
 
                     self.removeEvent()
 
-                    self.storage.updateQuestionStats(self.lineNumber, 1, 0)
+                    self.storage.updateQuestionStats(self.lineNumber, (4-self.hintsCounter), 0)
 
                     if self.stopPending == True:
                         self.stop()


### PR DESCRIPTION
Fixed #99 

Points subtracted for next time the question is asked.

First hint: -15
Second hint: -10
Third hint: -5
