### PR TITLE
Fixing group by on .week and .year

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -2576,7 +2576,7 @@ class TriviaTime(callbacks.Plugin):
                         from triviauserlog
                         where year=?
                         and channel_canonical=?
-                        group by username
+                        group by username_canonical
                         order by points_made desc
                         limit 10''', (year,channelCanonical))
 
@@ -2608,7 +2608,7 @@ class TriviaTime(callbacks.Plugin):
                         where ('''
             weekSql += weekSqlString
             weekSql += ''' ) and channel_canonical=?
-                            group by username
+                            group by username_canonical
                             order by points_made desc
                             limit 10
                         '''


### PR DESCRIPTION
When a user changes the case of their username it should group properly now when using .week and .year
